### PR TITLE
Update async library to M4

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -10,7 +10,7 @@ libraryDependencies ++= Seq(
 	"com.netflix.rxjava" % "rxjava-scala" % "0.15.0",
 	"org.scalatest" % "scalatest_2.10" % "2.0",
 	"junit" % "junit" % "4.11",
-	"org.scala-lang.modules" %% "scala-async" % "0.9.0-M2",
+	"org.scala-lang.modules" %% "scala-async" % "0.9.0-M4",
 	"com.squareup.retrofit" % "retrofit" % "1.2.2",
 	"com.typesafe.akka" %% "akka-actor" % "2.2.1"
 )


### PR DESCRIPTION
The M4 release fixes some issues with the presentation compiler. This
makes using `async/await` much more pleasant in the Scala IDE.
