### PR TITLE
Changes package declaration in Schedulers.scala (fixes eclipse JUnit runner throwing ClassNotFound)

### DIFF
--- a/src/test/scala/coursera/rx/Schedulers.scala
+++ b/src/test/scala/coursera/rx/Schedulers.scala
@@ -1,4 +1,4 @@
-package test.scala.coursera.rx
+package coursera.rx
 
 import rx.lang.scala.{Scheduler, Subscription, Observable}
 import scala.language.postfixOps


### PR DESCRIPTION
eclipse JUnit runner [1] throws ClassNotFound without this change

[1] Kepler SR1, Scala plugin 3.0.2
